### PR TITLE
Feat: 개인 리뷰 확인 REST API 구현

### DIFF
--- a/src/main/java/com/example/cloudproject/reviewapiserver/controller/ReviewController.java
+++ b/src/main/java/com/example/cloudproject/reviewapiserver/controller/ReviewController.java
@@ -1,5 +1,6 @@
 package com.example.cloudproject.reviewapiserver.controller;
 
+import com.example.cloudproject.reviewapiserver.dto.MyReviewDTO;
 import com.example.cloudproject.reviewapiserver.dto.ReviewDTO;
 import com.example.cloudproject.reviewapiserver.dto.StoreReviewDTO;
 import com.example.cloudproject.reviewapiserver.exception.AuthException;
@@ -79,6 +80,20 @@ public class ReviewController {
                 .build();
 
         return ResponseEntity.ok(reviewService.removeReview(requestDTO));
+    }
+
+    @GetMapping("/mine")
+    public ResponseEntity<MyReviewDTO.Response> getMyReviews(@ModelAttribute MyReviewDTO.Request requestDTO,
+                                                             HttpServletRequest servletRequest) {
+
+        Long userId = (Long) servletRequest.getAttribute("userId");
+        if (userId == -1) {
+            throw new AuthException(AuthExceptionType.UNAUTHORIZED_TOKEN);
+        }
+
+        requestDTO.setUserId(userId);
+
+        return ResponseEntity.ok(reviewService.getMyReviews(requestDTO));
     }
 
 }

--- a/src/main/java/com/example/cloudproject/reviewapiserver/dto/MyReviewDTO.java
+++ b/src/main/java/com/example/cloudproject/reviewapiserver/dto/MyReviewDTO.java
@@ -1,0 +1,68 @@
+package com.example.cloudproject.reviewapiserver.dto;
+
+import com.example.cloudproject.reviewapiserver.entity.Review;
+import lombok.*;
+
+import java.util.List;
+import java.util.UUID;
+
+public class MyReviewDTO {
+
+    @Getter
+    @EqualsAndHashCode()
+    @AllArgsConstructor
+    @Builder
+    public static class Info {
+
+        private Long storeId;
+        private String storeName;
+        private Byte grade;
+        private UUID image;
+        private String menu;
+        private String comment;
+        private List<Short> hashtags;
+        private Boolean isHidden;
+        private Boolean isAnonymous;
+
+        public static Info from(Review review, String storeName) {
+            return Info.builder()
+                    .storeId(review.getStoreId())
+                    .storeName(storeName)
+                    .grade(review.getGrade())
+                    .image(review.getImageUuid())
+                    .menu(review.getMenu())
+                    .comment(review.getComment())
+                    .hashtags(review.getHashtagIdList())
+                    .isHidden(review.getIsHidden())
+                    .isAnonymous(review.getIsAnonymous())
+                    .build();
+        }
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Request {
+
+        private static final Integer DEFAULT_ROW = 15;
+        private static final Integer DEFAULT_PAGE = 0;
+
+        private Long userId;
+        private Integer row = DEFAULT_ROW;
+        private Integer page = DEFAULT_PAGE;
+
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Response {
+
+        private Integer row;
+        private Integer page;
+        private List<MyReviewDTO.Info> reviews;
+
+    }
+}

--- a/src/main/java/com/example/cloudproject/reviewapiserver/dto/StoreNameDTO.java
+++ b/src/main/java/com/example/cloudproject/reviewapiserver/dto/StoreNameDTO.java
@@ -1,0 +1,46 @@
+package com.example.cloudproject.reviewapiserver.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+public class StoreNameDTO {
+
+    @Getter
+    @EqualsAndHashCode()
+    @AllArgsConstructor
+    @Builder
+    public static class Info {
+
+        private Long id;
+        private String name;
+
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Request {
+        List<Long> storeIdList;
+
+        public String getQuery() {
+            List<String> stringList = storeIdList.stream()
+                    .map(String::valueOf)
+                    .toList();
+
+            return "storeIdList=" + String.join(",", stringList);
+        }
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Response {
+
+        List<StoreNameDTO.Info> result;
+
+    }
+
+}

--- a/src/main/java/com/example/cloudproject/reviewapiserver/repository/ReviewRepository.java
+++ b/src/main/java/com/example/cloudproject/reviewapiserver/repository/ReviewRepository.java
@@ -8,5 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface ReviewRepository extends JpaRepository<Review, Review.ReviewPK> {
 
     Page<Review> findAllByStoreIdAndIsHiddenFalse(Long storeId, Pageable pageable);
+    Page<Review> findAllByUserId(Long userId, Pageable pageable);
 
 }

--- a/src/main/java/com/example/cloudproject/reviewapiserver/service/ReviewService.java
+++ b/src/main/java/com/example/cloudproject/reviewapiserver/service/ReviewService.java
@@ -17,7 +17,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -113,7 +112,7 @@ public class ReviewService {
                 .getContent();
 
         List<Long> storeIdList = reviewList.stream()
-                .map(review -> review.getStoreId())
+                .map(Review::getStoreId)
                 .toList();
 
         StoreNameDTO.Request storeRequestDTO = StoreNameDTO.Request.builder()

--- a/src/main/java/com/example/cloudproject/reviewapiserver/service/ReviewService.java
+++ b/src/main/java/com/example/cloudproject/reviewapiserver/service/ReviewService.java
@@ -1,11 +1,14 @@
 package com.example.cloudproject.reviewapiserver.service;
 
+import com.example.cloudproject.reviewapiserver.dto.MyReviewDTO;
 import com.example.cloudproject.reviewapiserver.dto.ReviewDTO;
+import com.example.cloudproject.reviewapiserver.dto.StoreNameDTO;
 import com.example.cloudproject.reviewapiserver.dto.StoreReviewDTO;
 import com.example.cloudproject.reviewapiserver.entity.Review;
 import com.example.cloudproject.reviewapiserver.exception.ReviewException;
 import com.example.cloudproject.reviewapiserver.exception.type.ReviewExceptionType;
 import com.example.cloudproject.reviewapiserver.repository.ReviewRepository;
+import com.example.cloudproject.reviewapiserver.util.WebClientUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataAccessException;
 import org.springframework.data.domain.Page;
@@ -14,7 +17,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -22,6 +29,7 @@ public class ReviewService {
 
     private final ReviewRepository reviewRepository;
     private final ImageService imageService;
+    private final WebClientUtil webClientUtil;
 
     public StoreReviewDTO.Response getStoreReviews(StoreReviewDTO.Request requestDTO) {
         Pageable pageable = PageRequest.of(
@@ -92,6 +100,39 @@ public class ReviewService {
         }
 
         return ReviewDTO.RemoveResponse.from(review);
+    }
+
+    public MyReviewDTO.Response getMyReviews(MyReviewDTO.Request requestDTO) {
+        Pageable pageable = PageRequest.of(
+                requestDTO.getPage(),
+                requestDTO.getRow(),
+                Sort.by(Sort.Direction.DESC, "createdAt")
+        );
+
+        List<Review> reviewList = reviewRepository.findAllByUserId(requestDTO.getUserId(), pageable)
+                .getContent();
+
+        List<Long> storeIdList = reviewList.stream()
+                .map(review -> review.getStoreId())
+                .toList();
+
+        StoreNameDTO.Request storeRequestDTO = StoreNameDTO.Request.builder()
+                .storeIdList(storeIdList)
+                .build();
+
+        Map<Long, String> storeIdNameMap = webClientUtil.getStoreNameList(storeRequestDTO)
+                .getResult().stream()
+                .collect(Collectors.toMap(StoreNameDTO.Info::getId, StoreNameDTO.Info::getName));
+
+        List<MyReviewDTO.Info> myReviewList = reviewList.stream()
+                .map(review -> MyReviewDTO.Info.from(review, storeIdNameMap.get(review.getStoreId())))
+                .toList();
+
+        return MyReviewDTO.Response.builder()
+                .row(requestDTO.getRow())
+                .page(requestDTO.getPage())
+                .reviews(myReviewList)
+                .build();
     }
 
 }

--- a/src/main/java/com/example/cloudproject/reviewapiserver/util/WebClientUtil.java
+++ b/src/main/java/com/example/cloudproject/reviewapiserver/util/WebClientUtil.java
@@ -10,8 +10,6 @@ import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 
-import java.util.List;
-
 @Component
 @RequiredArgsConstructor
 public class WebClientUtil {

--- a/src/main/java/com/example/cloudproject/reviewapiserver/util/WebClientUtil.java
+++ b/src/main/java/com/example/cloudproject/reviewapiserver/util/WebClientUtil.java
@@ -1,6 +1,7 @@
 package com.example.cloudproject.reviewapiserver.util;
 
 import com.example.cloudproject.reviewapiserver.dto.ReviewDTO;
+import com.example.cloudproject.reviewapiserver.dto.StoreNameDTO;
 import com.example.cloudproject.reviewapiserver.dto.UserDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -8,6 +9,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -48,5 +51,15 @@ public class WebClientUtil {
                 .retrieve()
                 .bodyToMono(Void.class)
                 .subscribe();
+    }
+
+    public StoreNameDTO.Response getStoreNameList(StoreNameDTO.Request requestDTO) {
+        return webClient.mutate()
+                .baseUrl("http://" + storeHostname + "/store/name?" + requestDTO.getQuery())
+                .build()
+                .get()
+                .retrieve()
+                .bodyToMono(StoreNameDTO.Response.class)
+                .block();
     }
 }


### PR DESCRIPTION
## 개요
개인이 작성한 리뷰 목록을 확인할 수 있는 REST API를 구현함

## 작업사항
- 개인 리뷰 목록 확인을 위한 GET /review/mine 구현

## 변경로직
- 가게 서버로부터 가게 이름을 가져오기 위한 요청 함수를 WebClientUtil에 추가
