### PR TITLE
Feat:가게 해시태그 업데이트 기능 구현

### DIFF
--- a/src/main/java/com/example/cloudproject/reviewapiserver/repository/ReviewRepository.java
+++ b/src/main/java/com/example/cloudproject/reviewapiserver/repository/ReviewRepository.java
@@ -5,9 +5,12 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ReviewRepository extends JpaRepository<Review, Review.ReviewPK> {
 
     Page<Review> findAllByStoreIdAndIsHiddenFalse(Long storeId, Pageable pageable);
     Page<Review> findAllByUserId(Long userId, Pageable pageable);
+    List<Review> findAllByStoreId(Long storeId);
 
 }


### PR DESCRIPTION
## 개요
 리뷰 상태 변경 시 가게의 top 3 해시태그와 평균 평점을 계산해 가게 서버에게 보내주는 기능을 구현함

## 작업사항
- ReviewService에 가게의 top 3 해시태그와 평균 평점을 계산해 가게 서버에게 보내주는 기능을 구현함

## 변경로직
- 구현한 기능을 리뷰 생성, 리뷰 수정, 리뷰 삭제 로직에 추가함
