### PR TITLE
Fix: 유저 인증 API 명세 변경으로 인한 코드 수정

### DIFF
--- a/src/main/java/com/example/cloudproject/reviewapiserver/dto/UserDTO.java
+++ b/src/main/java/com/example/cloudproject/reviewapiserver/dto/UserDTO.java
@@ -6,6 +6,7 @@ public class UserDTO {
 
     @Getter
     public static class AuthorizedResponse {
-        private Long id;
+        private Long PK;
+        private Boolean isKhu;
     }
 }

--- a/src/main/java/com/example/cloudproject/reviewapiserver/interceptor/UserAuthInterceptor.java
+++ b/src/main/java/com/example/cloudproject/reviewapiserver/interceptor/UserAuthInterceptor.java
@@ -37,10 +37,10 @@ public class UserAuthInterceptor implements HandlerInterceptor {
 
         UserDTO.AuthorizedResponse authResponse;
 
-        if (token == null || (authResponse = webClientUtil.getUserIdFromToken(token)) == null) {
+        if (token == null || (authResponse = webClientUtil.getUserIdFromToken(token)) == null || !authResponse.getIsKhu()) {
             request.setAttribute("userId", -1L);
         } else {
-            request.setAttribute("userId", authResponse.getId());
+            request.setAttribute("userId", authResponse.getPK());
         }
 
         return true;

--- a/src/main/java/com/example/cloudproject/reviewapiserver/util/WebClientUtil.java
+++ b/src/main/java/com/example/cloudproject/reviewapiserver/util/WebClientUtil.java
@@ -25,7 +25,7 @@ public class WebClientUtil {
 
     public UserDTO.AuthorizedResponse getUserIdFromToken(String token) {
         return webClient.mutate()
-                .baseUrl("http://" + userAuthHostname + "/login")
+                .baseUrl("http://" + userAuthHostname + "/authorization")
                 .defaultHeaders(headers -> headers.setBearerAuth(token))
                 .build()
                 .post()


### PR DESCRIPTION
## 개요
유저 인증 API 명세 변경으로 인해 동작하지 않는 코드를 수정함

## 작업사항
- 유저 인증을 한 뒤 경희대생이 아니면 인증에 실패하도록 조건을 추가함

## 변경로직
- 유저 인증을 요청하는 url을 변경함
- Response의 key를 API 명세서에 맞게 수정함
