### PR TITLE
Fix:페이지 목록을 보여주는 API의 명세 변경으로 인한 코드 수정

### DIFF
--- a/src/main/java/com/example/cloudproject/reviewapiserver/dto/MyReviewDTO.java
+++ b/src/main/java/com/example/cloudproject/reviewapiserver/dto/MyReviewDTO.java
@@ -60,8 +60,7 @@ public class MyReviewDTO {
     @Builder
     public static class Response {
 
-        private Integer row;
-        private Integer page;
+        private PageDTO pageInfo;
         private List<MyReviewDTO.Info> reviews;
 
     }

--- a/src/main/java/com/example/cloudproject/reviewapiserver/dto/PageDTO.java
+++ b/src/main/java/com/example/cloudproject/reviewapiserver/dto/PageDTO.java
@@ -1,0 +1,31 @@
+package com.example.cloudproject.reviewapiserver.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.springframework.data.domain.Page;
+
+@Data
+@EqualsAndHashCode
+@AllArgsConstructor
+@Builder
+public class PageDTO {
+
+    private Integer page;
+    private Integer row;
+    private Integer elements;
+    private Long totalElements;
+    private Integer totalPages;
+
+    public static <T> PageDTO from(Page<T> page) {
+        return PageDTO.builder()
+                .page(page.getNumber())
+                .row(page.getSize())
+                .elements(page.getNumberOfElements())
+                .totalElements(page.getTotalElements())
+                .totalPages(page.getTotalPages())
+                .build();
+    }
+
+}

--- a/src/main/java/com/example/cloudproject/reviewapiserver/dto/RecentReviewDTO.java
+++ b/src/main/java/com/example/cloudproject/reviewapiserver/dto/RecentReviewDTO.java
@@ -55,8 +55,7 @@ public class RecentReviewDTO {
     @Builder
     public static class Response {
 
-        private Integer row;
-        private Integer page;
+        private PageDTO pageInfo;
         private List<RecentReviewDTO.Info> reviews;
 
     }

--- a/src/main/java/com/example/cloudproject/reviewapiserver/dto/StoreReviewDTO.java
+++ b/src/main/java/com/example/cloudproject/reviewapiserver/dto/StoreReviewDTO.java
@@ -54,8 +54,7 @@ public class StoreReviewDTO {
     @Builder
     public static class Response {
 
-        private Integer row;
-        private Integer page;
+        private PageDTO pageInfo;
         private List<StoreReviewDTO.Info> reviews;
 
     }

--- a/src/main/java/com/example/cloudproject/reviewapiserver/service/ReviewService.java
+++ b/src/main/java/com/example/cloudproject/reviewapiserver/service/ReviewService.java
@@ -40,8 +40,7 @@ public class ReviewService {
                 .map(StoreReviewDTO.Info::from);
 
         return StoreReviewDTO.Response.builder()
-                .page(requestDTO.getPage())
-                .row(requestDTO.getRow())
+                .pageInfo(PageDTO.from(page))
                 .reviews(page.getContent())
                 .build();
     }
@@ -112,8 +111,9 @@ public class ReviewService {
                 Sort.by(Sort.Direction.DESC, "createdAt")
         );
 
-        List<Review> reviewList = reviewRepository.findAllByUserId(requestDTO.getUserId(), pageable)
-                .getContent();
+        Page<Review> page = reviewRepository.findAllByUserId(requestDTO.getUserId(), pageable);
+
+        List<Review> reviewList = page.getContent();
 
         List<Long> storeIdList = reviewList.stream()
                 .map(Review::getStoreId)
@@ -126,8 +126,7 @@ public class ReviewService {
                 .toList();
 
         return MyReviewDTO.Response.builder()
-                .row(requestDTO.getRow())
-                .page(requestDTO.getPage())
+                .pageInfo(PageDTO.from(page))
                 .reviews(myReviewList)
                 .build();
     }
@@ -139,8 +138,9 @@ public class ReviewService {
                 Sort.by(Sort.Direction.DESC, "createdAt")
         );
 
-        List<Review> reviewList = reviewRepository.findAll(pageable)
-                .getContent();
+        Page<Review> page = reviewRepository.findAll(pageable);
+
+        List<Review> reviewList = page.getContent();
 
         List<Long> storeIdList = reviewList.stream()
                 .map(Review::getStoreId)
@@ -153,8 +153,7 @@ public class ReviewService {
                 .toList();
 
         return RecentReviewDTO.Response.builder()
-                .row(requestDTO.getRow())
-                .page(requestDTO.getPage())
+                .pageInfo(PageDTO.from(page))
                 .reviews(recentReviewList)
                 .build();
     }


### PR DESCRIPTION
## 개요
페이지 목록을 보여주는 API인 StoreReview, MyReview, RecentReview의 Response를 API 명세에 맞게 변경함

## 작업사항
- 페이지 정보를 저장하는 PageDTO를 추가함

## 변경로직
- StoreReviewDTO, MyReviewDTO, RecentReviewDTO의 Response에 
page, row 대신 PageDTO를 저장할 pageInfo 변수를 추가함
- ReviewService 로직에 변경된 DTO를 반영함
