### PR TITLE
Feat: authorization 토큰을 header가 아닌 body로 전송

### DIFF
--- a/src/main/java/com/example/cloudproject/reviewapiserver/dto/UserDTO.java
+++ b/src/main/java/com/example/cloudproject/reviewapiserver/dto/UserDTO.java
@@ -8,6 +8,14 @@ public class UserDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     @Builder
+    public static class AuthorizedRequest {
+        private String token;
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
     public static class AuthorizedResponse {
         private Long id;
     }

--- a/src/main/java/com/example/cloudproject/reviewapiserver/util/WebClientUtil.java
+++ b/src/main/java/com/example/cloudproject/reviewapiserver/util/WebClientUtil.java
@@ -24,11 +24,15 @@ public class WebClientUtil {
 
 
     public UserDTO.AuthorizedResponse getUserIdFromToken(String token) {
+        UserDTO.AuthorizedRequest requestDTO = UserDTO.AuthorizedRequest.builder()
+                .token(token)
+                .build();
+
         return webClient.mutate()
-                .baseUrl("http://" + userAuthHostname + "/login")
-                .defaultHeaders(headers -> headers.setBearerAuth(token))
+                .baseUrl("http://" + userAuthHostname + "/authorization")
                 .build()
                 .post()
+                .bodyValue(requestDTO)
                 .exchangeToMono(response -> {
                     if (response.statusCode() == HttpStatus.OK) {
                         return response.bodyToMono(UserDTO.AuthorizedResponse.class);


### PR DESCRIPTION
## 개요
사용자 인증 토큰을 body로 보내도록 로직을 수정함

## 작업사항
- request를 보내기 위한 UserDTO.AuthorizedRequest DTO를 추가함

## 변경로직
- Web Client에서 token을 header가 아닌 body로 보내도록 수정함
